### PR TITLE
Bump shiro-spring from 1.4.0 to 1.7.1 in /springboot-summarizing

### DIFF
--- a/springboot-summarizing/pom.xml
+++ b/springboot-summarizing/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.apache.shiro</groupId>
 			<artifactId>shiro-spring</artifactId>
-			<version>1.4.0</version>
+			<version>1.7.1</version>
 		</dependency>
 
 


### PR DESCRIPTION
Bumps shiro-spring from 1.4.0 to 1.7.1.

---
updated-dependencies:
- dependency-name: org.apache.shiro:shiro-spring dependency-type: direct:production ...